### PR TITLE
Add on-prem support to NodeJs SDK

### DIFF
--- a/packages/playht/src/api/APISettingsStore.ts
+++ b/packages/playht/src/api/APISettingsStore.ts
@@ -18,6 +18,7 @@ export class APISettingsStore {
     this.gRpcClient = new Client({
       userId: settings.userId,
       apiKey: settings.apiKey,
+      onPremEndpoint: settings.onPremEndpoint,
     });
 
     APISettingsStore._instance = this;

--- a/packages/playht/src/index.ts
+++ b/packages/playht/src/index.ts
@@ -378,6 +378,7 @@ export type APISettingsInput = {
   userId: string;
   defaultVoiceId?: string;
   defaultVoiceEngine?: VoiceEngine;
+  onPremEndpoint?: string;
 };
 
 /**


### PR DESCRIPTION
Clients can optionally specify the endpoint of their on-prem appliance in PlayHT.init(...).  Subsequent gRPC requests using the PlayHT2.0-turbo engine will be sent to their on-prem endpoint instead of the shared endpoint.

Read more about PlayHT On-Prem here: https://docs.play.ht/reference/on-prem