### PR TITLE
Add a fallback option when the on-prem is overloaded

### DIFF
--- a/packages/playht/src/api/APISettingsStore.ts
+++ b/packages/playht/src/api/APISettingsStore.ts
@@ -19,6 +19,7 @@ export class APISettingsStore {
       userId: settings.userId,
       apiKey: settings.apiKey,
       onPremEndpoint: settings.onPremEndpoint,
+      onPremFallback: settings.onPremFallback,
     });
 
     APISettingsStore._instance = this;
@@ -47,9 +48,11 @@ export class APISettingsStore {
         'Please enter a valid api key and user ID. Please refer to https://docs.play.ht/reference/api-authentication for more info.',
       );
     }
+    console.info(settings)
     new APISettingsStore({
       defaultVoiceEngine: DEFAULT_VOICE_ENGINE,
       defaultVoiceId: DEFAULT_VOICE_ID,
+      onPremFallback: true,
       ...settings,
     });
   }

--- a/packages/playht/src/api/APISettingsStore.ts
+++ b/packages/playht/src/api/APISettingsStore.ts
@@ -48,7 +48,6 @@ export class APISettingsStore {
         'Please enter a valid api key and user ID. Please refer to https://docs.play.ht/reference/api-authentication for more info.',
       );
     }
-    console.info(settings)
     new APISettingsStore({
       defaultVoiceEngine: DEFAULT_VOICE_ENGINE,
       defaultVoiceId: DEFAULT_VOICE_ID,

--- a/packages/playht/src/api/APISettingsStore.ts
+++ b/packages/playht/src/api/APISettingsStore.ts
@@ -51,7 +51,7 @@ export class APISettingsStore {
     new APISettingsStore({
       defaultVoiceEngine: DEFAULT_VOICE_ENGINE,
       defaultVoiceId: DEFAULT_VOICE_ID,
-      fallbackEnabled: true,
+      fallbackEnabled: false,
       ...settings,
     });
   }

--- a/packages/playht/src/api/APISettingsStore.ts
+++ b/packages/playht/src/api/APISettingsStore.ts
@@ -18,8 +18,8 @@ export class APISettingsStore {
     this.gRpcClient = new Client({
       userId: settings.userId,
       apiKey: settings.apiKey,
-      onPremEndpoint: settings.onPremEndpoint,
-      onPremFallback: settings.onPremFallback,
+      customAddr: settings.customAddr,
+      fallbackEnabled: settings.fallbackEnabled,
     });
 
     APISettingsStore._instance = this;
@@ -52,7 +52,7 @@ export class APISettingsStore {
     new APISettingsStore({
       defaultVoiceEngine: DEFAULT_VOICE_ENGINE,
       defaultVoiceId: DEFAULT_VOICE_ID,
-      onPremFallback: true,
+      fallbackEnabled: true,
       ...settings,
     });
   }

--- a/packages/playht/src/grpc-client/client.ts
+++ b/packages/playht/src/grpc-client/client.ts
@@ -100,7 +100,7 @@ export class Client {
     this.lease = await this.leasePromise;
     this.leasePromise = undefined;
 
-    let address = this.options.customAddr ?? this.lease.metadata.inference_address;
+    const address = this.options.customAddr ?? this.lease.metadata.inference_address;
     if (!address) {
       throw new Error('Service address not found');
     }
@@ -119,7 +119,7 @@ export class Client {
       };
     }
 
-    let premiumAddress = this.lease.metadata.premium_inference_address;
+    const premiumAddress = this.lease.metadata.premium_inference_address;
     if (!premiumAddress) {
       throw new Error('Premium service address not found');
     }

--- a/packages/playht/src/grpc-client/client.ts
+++ b/packages/playht/src/grpc-client/client.ts
@@ -57,7 +57,7 @@ export class Client {
       throw new Error('userId and apiKey are required');
     }
     if (options.fallbackEnabled == undefined) {
-      options.fallbackEnabled = true
+      options.fallbackEnabled = false
     }
     this.apiUrl = 'https://api.play.ht/api';
     const authHeader = options.apiKey.startsWith('Bearer ') ? options.apiKey : `Bearer ${options.apiKey}`;
@@ -100,8 +100,7 @@ export class Client {
     this.lease = await this.leasePromise;
     this.leasePromise = undefined;
 
-    let address = this.lease.metadata.inference_address;
-    if (this.options.customAddr) address = this.options.customAddr
+    let address = this.options.customAddr ?? this.lease.metadata.inference_address;
     if (!address) {
       throw new Error('Service address not found');
     }
@@ -140,9 +139,9 @@ export class Client {
     }
 
     if (this.options.customAddr) {
-      const customAddress: string = this.options.customAddr!
-      if (this.customRpc && this.customRpc!.address !== customAddress) {
-        this.customRpc!.client.close();
+      const customAddress: string = this.options.customAddr
+      if (this.customRpc && this.customRpc.address !== customAddress) {
+        this.customRpc.client.close();
         this.customRpc = undefined;
       }
 
@@ -150,10 +149,10 @@ export class Client {
         const insecure = customAddress.includes("on-prem.play.ht") || USE_INSECURE_CONNECTION
         this.customRpc = {
           client: new GrpcClient(
-              customAddress!,
+              customAddress,
               insecure ? credentials.createInsecure() : credentials.createSsl(),
           ),
-          address: customAddress!,
+          address: customAddress,
         };
       }
     }

--- a/packages/playht/src/grpc-client/tts-stream-source.ts
+++ b/packages/playht/src/grpc-client/tts-stream-source.ts
@@ -66,16 +66,14 @@ export class TTSStreamSource implements UnderlyingByteSource {
       }
     });
     this.stream.on('error', (err) => {
-      if (this.retryable) {
-        // if we get an error while this stream source is still retryable (i.e. we haven't started streaming data back and haven't canceled)
-        // then we can fallback if there is a fallback rpc client
-        if (fallbackClient) {
-          this.end();
-          // start again with the fallback client and the primary client
-          // we won't specify a second order fallback client - so if this client fails, this stream will fail
-          this.startAndMaybeFallback(controller, fallbackClient, undefined);
-          return;
-        }
+      // if we get an error while this stream source is still retryable (i.e. we haven't started streaming data back and haven't canceled)
+      // then we can fallback if there is a fallback rpc client
+      if (this.retryable && fallbackClient) {
+        this.end();
+        // start again with the fallback client and the primary client
+        // we won't specify a second order fallback client - so if this client fails, this stream will fail
+        this.startAndMaybeFallback(controller, fallbackClient, undefined);
+        return;
 
       }
 

--- a/packages/playht/src/grpc-client/tts-stream-source.ts
+++ b/packages/playht/src/grpc-client/tts-stream-source.ts
@@ -1,27 +1,45 @@
 import type * as grpc from '@grpc/grpc-js';
 import * as apiProto from './protos/api';
 
+enum State {
+  CREATED,
+  STARTING,
+  STARTED,
+  STREAMING,
+  ERR,
+  DONE
+}
+
 export class TTSStreamSource implements UnderlyingByteSource {
   private stream?: grpc.ClientReadableStream<apiProto.playht.v1.TtsResponse>;
   readonly type = 'bytes';
+  private state: State = State.CREATED;
 
   constructor(
     private readonly request: apiProto.playht.v1.ITtsRequest,
     private readonly rpcClient: grpc.Client,
+    private readonly fallbackClient?: grpc.Client,
   ) {}
 
   start(controller: ReadableByteStreamController) {
+    this.startAndMaybeFallback(controller, this.rpcClient, this.fallbackClient);
+  }
+
+  startAndMaybeFallback(controller: ReadableByteStreamController, client: grpc.Client, fallbackClient?: grpc.Client) {
+    this.state = State.STARTING;
     try {
       if (controller.byobRequest) {
         throw new Error("Don't know how to handle byobRequest");
       }
-      this.stream = this.rpcClient.makeServerStreamRequest(
-        '/playht.v1.Tts/Tts',
-        (arg) => apiProto.playht.v1.TtsRequest.encode(arg).finish() as any,
-        (arg) => apiProto.playht.v1.TtsResponse.decode(arg),
-        this.request,
+      this.stream = client.makeServerStreamRequest(
+          '/playht.v1.Tts/Tts',
+          (arg) => apiProto.playht.v1.TtsRequest.encode(arg).finish() as any,
+          (arg) => apiProto.playht.v1.TtsResponse.decode(arg),
+          this.request,
       );
+      this.state = State.STARTED;
     } catch (error: any) {
+      this.state = State.ERR;
       const errorDetail = error?.errorMessage || error?.details || error?.message || 'Unknown error';
       const errorMessage = `[PlayHT SDK] Error creating stream: ${errorDetail}`;
       console.error(errorMessage);
@@ -30,6 +48,7 @@ export class TTSStreamSource implements UnderlyingByteSource {
     }
 
     this.stream.on('data', (data: apiProto.playht.v1.TtsResponse) => {
+      if(this.state == State.STARTED) this.state = State.STREAMING;
       if (data.status) {
         switch (data.status.code) {
           case apiProto.playht.v1.Code.CODE_COMPLETE:
@@ -46,6 +65,7 @@ export class TTSStreamSource implements UnderlyingByteSource {
           }
           default: {
             if (this.end()) {
+              this.state = State.ERR;
               controller.error(new Error(`Unknown status code: ${data.status.code}`));
             }
             return;
@@ -59,12 +79,28 @@ export class TTSStreamSource implements UnderlyingByteSource {
       }
     });
     this.stream.on('error', (err) => {
+      if (this.state == State.STARTED) {
+        // if we get an error before we've actually started streaming data
+        // then we can fallback if there is a fallback rpc client
+        if (fallbackClient) {
+          this.end();
+          // start again with the fallback client and the primary client
+          // we won't specify a second order fallback client - so if this client fails, this stream will fail
+          this.startAndMaybeFallback(controller, fallbackClient, undefined);
+          return;
+        }
+
+      }
+
+      // if we reach here - we couldn't fallback and therefore this stream has failed
       if (this.end()) {
+        this.state = State.ERR;
         controller.error(err);
       }
     });
     this.stream.on('end', () => {
       if (this.end()) {
+        this.state = State.DONE;
         controller.close();
       }
     });

--- a/packages/playht/src/index.ts
+++ b/packages/playht/src/index.ts
@@ -378,8 +378,8 @@ export type APISettingsInput = {
   userId: string;
   defaultVoiceId?: string;
   defaultVoiceEngine?: VoiceEngine;
-  onPremEndpoint?: string;
-  onPremFallback?: boolean;
+  customAddr?: string;
+  fallbackEnabled?: boolean;
 };
 
 /**

--- a/packages/playht/src/index.ts
+++ b/packages/playht/src/index.ts
@@ -372,13 +372,30 @@ export type SpeechOutput = {
  * not defined.
  * @property {VoiceEngine} [defaultVoiceEngine] - An optional default voice engine to be used in speech synthesis when
  * a voice engine is not defined.
+ * @property {string} [customAddr] - An optional custom address (host:port) to send requests to.
+ * @property {string} [fallbackEnabled] - If true, the client may choose to, under high load scenarios, fallback
+ * from a custom address (configured with "customAddr" above) to the standard PlayHT address.
  */
 export type APISettingsInput = {
   apiKey: string;
   userId: string;
   defaultVoiceId?: string;
   defaultVoiceEngine?: VoiceEngine;
+
+  /**
+   * An optional custom address (host:port) to send requests to.
+   *
+   * If you're using PlayHT On-Prem (https://docs.play.ht/reference/on-prem), then you should set
+   * customAddr to be the address of your PlayHT On-Prem appliance (e.g. my-company-000001.on-prem.play.ht:11045).
+   *
+   * Keep in mind that your PlayHT On-Prem appliance can only be used with the PlayHT2.0-Turbo voice engine for streaming.
+   */
   customAddr?: string;
+
+  /**
+   * If true, the client may choose to, under high load scenarios, fallback from a custom address
+   * (configured with "customAddr" above) to the standard PlayHT address.
+   */
   fallbackEnabled?: boolean;
 };
 

--- a/packages/playht/src/index.ts
+++ b/packages/playht/src/index.ts
@@ -379,6 +379,7 @@ export type APISettingsInput = {
   defaultVoiceId?: string;
   defaultVoiceEngine?: VoiceEngine;
   onPremEndpoint?: string;
+  onPremFallback?: boolean;
 };
 
 /**


### PR DESCRIPTION
Add a fallback option (default is on) so that TTS requests to an on-prem appliance that is over capacity or down can fallback to the shared PlayHT endpoint.

Customers will use it like this:

```
PlayHT.init({
  apiKey: "8ba8f2bd9f974ee6bfc3f9235732d2ee",
  userId: "QoXF1BTwdLa5dHr2jhcjyjEcFVj2",
  customAddr: "my-company.on-prem.play.ht:11045",
  fallbackEnabled: true
});
```