### PR TITLE
Fix a critical bug in the fallback logic - which caused the client to fallback to the same primary custom addr.

### DIFF
--- a/packages/playht/src/grpc-client/client.ts
+++ b/packages/playht/src/grpc-client/client.ts
@@ -138,7 +138,7 @@ export class Client {
       this.leasePromise = undefined;
     }
 
-    const address = this.options.customAddr ?? this.lease.metadata.inference_address;
+    const address = this.lease.metadata.inference_address;
     if (!address) {
       throw new Error('Service address not found');
     }

--- a/packages/playht/src/grpc-client/tts-stream-source.ts
+++ b/packages/playht/src/grpc-client/tts-stream-source.ts
@@ -69,6 +69,7 @@ export class TTSStreamSource implements UnderlyingByteSource {
       // if we get an error while this stream source is still retryable (i.e. we haven't started streaming data back and haven't canceled)
       // then we can fallback if there is a fallback rpc client
       if (this.retryable && fallbackClient) {
+        console.warn(`Falling back...`, fallbackClient.getChannel().getTarget());
         this.end();
         // start again with the fallback client and the primary client
         // we won't specify a second order fallback client - so if this client fails, this stream will fail


### PR DESCRIPTION
Fix a critical bug in the fallback logic - which caused the client to fallback to the same primary custom addr.

Add logging when fallback occurs.