### PR TITLE
Introduce configurable congestion control.

### DIFF
--- a/packages/playht/src/api/APISettingsStore.ts
+++ b/packages/playht/src/api/APISettingsStore.ts
@@ -20,6 +20,7 @@ export class APISettingsStore {
       apiKey: settings.apiKey,
       customAddr: settings.customAddr,
       fallbackEnabled: settings.fallbackEnabled,
+      congestionCtrl: settings.congestionCtrl,
     });
 
     APISettingsStore._instance = this;

--- a/packages/playht/src/grpc-client/client.ts
+++ b/packages/playht/src/grpc-client/client.ts
@@ -138,7 +138,7 @@ export class Client {
       this.leasePromise = undefined;
     }
 
-    const address = this.options.customAddr ?? this.lease.metadata.inference_address;
+    const address = this.lease.metadata.inference_address;
     if (!address) {
       throw new Error('Service address not found');
     }

--- a/packages/playht/src/grpc-client/client.ts
+++ b/packages/playht/src/grpc-client/client.ts
@@ -4,6 +4,7 @@ import apiProto from './protos/api';
 import { Lease } from './lease';
 import { ReadableStream } from './readable-stream';
 import { TTSStreamSource } from './tts-stream-source';
+import {CongestionCtrl} from "../index";
 
 export type TTSParams = apiProto.playht.v1.ITtsParams;
 export const Quality = apiProto.playht.v1.Quality;
@@ -35,6 +36,11 @@ export interface ClientOptions {
    * (configured with "customAddr" above) to the standard PlayHT address.
    */
   fallbackEnabled?: boolean;
+
+  /**
+   * @see CongestionCtrl
+   */
+  congestionCtrl?: CongestionCtrl;
 }
 
 const USE_INSECURE_CONNECTION = false;
@@ -219,7 +225,8 @@ export class Client {
       rpcClient = isPremium ? this.premiumRpc!.client : this.rpc!.client;
       fallbackClient = undefined;
     }
-    const stream = new ReadableStream(new TTSStreamSource(request, rpcClient, fallbackClient));
+    const congestionCtrl = this.options.congestionCtrl ?? CongestionCtrl.Off;
+    const stream = new ReadableStream(new TTSStreamSource(request, rpcClient, fallbackClient, congestionCtrl));
     // fix for TypeScript not DOM types not including Symbol.asyncIterator in ReadableStream
     return stream as unknown as AsyncIterable<Uint8Array> & ReadableStream<Uint8Array>;
   }

--- a/packages/playht/src/grpc-client/tts-stream-source.ts
+++ b/packages/playht/src/grpc-client/tts-stream-source.ts
@@ -69,7 +69,7 @@ export class TTSStreamSource implements UnderlyingByteSource {
       // if we get an error while this stream source is still retryable (i.e. we haven't started streaming data back and haven't canceled)
       // then we can fallback if there is a fallback rpc client
       if (this.retryable && fallbackClient) {
-        console.warn(`Falling back...`, fallbackClient.getChannel().getTarget());
+        console.warn(`[PlayHT SDK] Falling back...`, fallbackClient.getChannel().getTarget(), err.message);
         this.end();
         // start again with the fallback client and the primary client
         // we won't specify a second order fallback client - so if this client fails, this stream will fail

--- a/packages/playht/src/grpc-client/tts-stream-source.ts
+++ b/packages/playht/src/grpc-client/tts-stream-source.ts
@@ -69,6 +69,7 @@ export class TTSStreamSource implements UnderlyingByteSource {
       // if we get an error while this stream source is still retryable (i.e. we haven't started streaming data back and haven't canceled)
       // then we can fallback if there is a fallback rpc client
       if (this.retryable && fallbackClient) {
+        console.warn(`Falling back...`, fallbackClient.getChannel().getTarget());
         this.end();
         // start again with the fallback client and the primary client
         // we won't specify a second order fallback client - so if this client fails, this stream will fail

--- a/packages/playht/src/grpc-client/tts-stream-source.ts
+++ b/packages/playht/src/grpc-client/tts-stream-source.ts
@@ -1,16 +1,46 @@
 import type * as grpc from '@grpc/grpc-js';
 import * as apiProto from './protos/api';
+import {CongestionCtrl} from "../index";
 
 export class TTSStreamSource implements UnderlyingByteSource {
   private stream?: grpc.ClientReadableStream<apiProto.playht.v1.TtsResponse>;
   readonly type = 'bytes';
   private retryable = true;
+  private retries = 0;
+  private maxRetries = 0;
+  private backoff = 0;
 
   constructor(
     private readonly request: apiProto.playht.v1.ITtsRequest,
     private readonly rpcClient: grpc.Client,
     private readonly fallbackClient?: grpc.Client,
-  ) {}
+    private readonly congestionCtrl?: CongestionCtrl
+  ) {
+    if (congestionCtrl != undefined) {
+      switch (congestionCtrl) {
+        case CongestionCtrl.Off:
+          this.maxRetries = 0;
+          this.backoff = 0;
+          break;
+        case CongestionCtrl.StaticMar2024:
+          /**
+           * NOTE:
+           *
+           * The values below were experimentally chosen.
+           *
+           * The experiments were not rigorous and certainly leave a lot to be desired. We should tune them over time.
+           * We might end up with something dynamic inspired by additive-increase-multiplicative-decrease.
+           *
+           * --mtp@2024/02/28
+           */
+          this.maxRetries = 2;
+          this.backoff = 50;
+          break;
+        default:
+          throw new Error(`Unrecognized congestion control algorithm: ${congestionCtrl}`);
+      }
+    }
+  }
 
   start(controller: ReadableByteStreamController) {
     this.startAndMaybeFallback(controller, this.rpcClient, this.fallbackClient);
@@ -66,15 +96,30 @@ export class TTSStreamSource implements UnderlyingByteSource {
       }
     });
     this.stream.on('error', (err) => {
+
       // if we get an error while this stream source is still retryable (i.e. we haven't started streaming data back and haven't canceled)
-      // then we can fallback if there is a fallback rpc client
-      if (this.retryable && fallbackClient) {
-        console.warn(`[PlayHT SDK] Falling back...`, fallbackClient.getChannel().getTarget(), err.message);
-        this.end();
-        // start again with the fallback client and the primary client
-        // we won't specify a second order fallback client - so if this client fails, this stream will fail
-        this.startAndMaybeFallback(controller, fallbackClient, undefined);
-        return;
+      // then we can retry or fall back (if there is a fallback rpc client)
+      if (this.retryable) {
+        if (this.retries < this.maxRetries) {
+          this.end();
+          this.retries++;
+          // NOTE: It's a poor customer experience to show internal details about retries -- so we don't log here.  TCP has the same policy.
+          //console.debug(`[PlayHT SDK] Retrying in ${this.backoff} ms ... (${this.retries} attempts so far)`, err.message);
+          // retry with the same primary and fallback client
+          setTimeout(() => {
+            this.startAndMaybeFallback(controller, client, fallbackClient);
+          }, this.backoff)
+
+        } else if (fallbackClient) {
+          // NOTE: We log fallbacks to give customers a signal that they should scale up their on-prem appliance (e.g. by paying for more GPU quota)
+          console.warn(`[PlayHT SDK] Falling back to ${fallbackClient.getChannel().getTarget()} ...`, err.message);
+          this.end();
+          this.retries = 0;
+          // start again with the fallback client and the primary client
+          // we won't specify a second order fallback client - so if this client fails, this stream will fail
+          this.startAndMaybeFallback(controller, fallbackClient, undefined);
+          return;
+        }
       }
 
       // if we reach here - we couldn't fallback and therefore this stream has failed

--- a/packages/playht/src/index.ts
+++ b/packages/playht/src/index.ts
@@ -397,7 +397,35 @@ export type APISettingsInput = {
    * (configured with "customAddr" above) to the standard PlayHT address.
    */
   fallbackEnabled?: boolean;
+
+  /**
+   * If specified, the client will use the specified {@link CongestionCtrl} algorithm to optimize
+   * the rate at which it sends text to PlayHT.
+   *
+   * If you're using PlayHT On-Prem, you should set this to {@link CongestionCtrl#StaticMar2024}.
+   *
+   * @see CongestionCtrl
+   */
+  congestionCtrl?: CongestionCtrl;
 };
+
+/**
+ * Enumerates a streaming congestion control algorithms, used to optimize the rate at which text is sent to PlayHT.
+ */
+export enum CongestionCtrl {
+
+  /**
+   * The client will not do any congestion control.  Text will be sent to PlayHT as fast as possible.
+   */
+  Off,
+
+  /**
+   * The client will optimize for minimizing the number of physical resources required to handle a single stream.
+   *
+   * If you're using PlayHT On-Prem, you should use this {@link CongestionCtrl} algorithm.
+   */
+  StaticMar2024
+}
 
 /**
  * Initializes the library with API credentials.


### PR DESCRIPTION
Introduce configurable congestion control.

The primary motivation for this (as of 2024/02/28) is to protect PlayHT On-Prem appliance from being inundated with a burst text-to-speech requests that it can't satisfy.

Prior to this change, the client would split a text stream into two text chunks (referred to as "sentences") and send them to the API client (i.e. gRPC client) simultaneously.  This would routinely overload on-prem appliances that operate without a lot of GPU capacity headroom[1].  The result would be that most requests that clients sent would immediately result in a gRPC error 8: RESOURCE_EXHAUSTED; and therefore, a bad customer experience.

This change introduces allows customers to turn on one of a enumerated set of congestion control algorithms.  We've implemented just one for now, StaticMar2024, which delays sending subsequent text chunks (i.e. sentences) to the gRPC client until audio for the preceding text chunk has started streaming. This is a very simple congestion control algorithm with static constants; it leaves a lot to be desired.  We should iterate on these algorithms in the future.  The CongestionCtrl enum was added so that algorithms can be added without requiring customers to change their code much.

[1] Customers tend to be very cost sensitive regarding expensive GPU capacity, and therefore want to keep their appliances running near 100% utilization.