### PR TITLE
Updated punctuation regex for correct handling floats, times

### DIFF
--- a/packages/playht/src/api/constants.ts
+++ b/packages/playht/src/api/constants.ts
@@ -3,5 +3,5 @@ export const GRPC_STREAMING_LIMITS = {
   LINE_MAX_LENGTH: 300,
   LINE_DESIRED_LENGTH: 200,
 };
-export const PUNCTUATION_REGEX = /[.!?:…\r\n]/m;
+export const PUNCTUATION_REGEX = /((?<!\d)[.:](?!\d))|[!?…\r\n]/m;
 export const STREAM_SENTENCE_AGGREGATE_TIMEOUT = 150;


### PR DESCRIPTION
This PR addresses an issue in PlayHT where text was incorrectly split into sentences at numbers containing decimals (e.g., 123.45) or times (e.g., 10:32) were present in the text, which is not the intended behavior.


It works for our projects. You would test it additionally