### PR TITLE
Close audio stream when the input is empty

### DIFF
--- a/packages/playht/src/api/apiCommon.ts
+++ b/packages/playht/src/api/apiCommon.ts
@@ -291,13 +291,15 @@ async function audioStreamFromSentences(
   promiseStream.on('error', onError);
 
   promiseStream.on('end', () => {
-    setTimeout(
-      () =>
-        writeAudio.on('finish', () => {
-          writableStream.end();
-        }),
-      0,
-    );
+    setTimeout(() => {
+      if (writeAudio.closed) {
+        writableStream.end();
+        return;
+      }
+      writeAudio.on('finish', () => {
+        writableStream.end();
+      });
+    }, 0);
   });
 
   promiseStream.pipe(writeAudio);


### PR DESCRIPTION
When the input stream is closed without any data, writeAudio seems to get closed before the setTimeout callback is run.