### PR TITLE
Add missing `'PlayDialog-turbo'` to `VoiceEngine` options

### DIFF
--- a/packages/playht/src/index.ts
+++ b/packages/playht/src/index.ts
@@ -14,7 +14,7 @@ import { defaultConfigWithOverrides } from './api/internal/settings/defaultConfi
  * For the lowest latency, use `Play3.0-mini`.
  * For the highest quality, use `PlayDialog`.
  */
-export type VoiceEngine = 'PlayDialog' | 'Play3.0-mini' | 'PlayHT2.0-turbo' | 'PlayHT2.0' | 'PlayHT1.0' | 'Standard';
+export type VoiceEngine = 'PlayDialog' | 'PlayDialog-turbo' | 'Play3.0-mini' | 'PlayHT2.0-turbo' | 'PlayHT2.0' | 'PlayHT1.0' | 'Standard';
 
 /**
  * Type representing the different input types that can be used to define the format of the input text.


### PR DESCRIPTION
**Description:**  
The `'PlayDialog-turbo'` voice engine was missing from the `VoiceEngine` type definition, even though the model is supported by the package. This update adds the missing option to ensure accurate type coverage and prevent potential runtime mismatches.

**Changes Made:**
```ts
export type VoiceEngine = 'PlayDialog' | 'PlayDialog-turbo' | 'Play3.0-mini' | 'PlayHT2.0-turbo' | 'PlayHT2.0' | 'PlayHT1.0' | 'Standard';
